### PR TITLE
Add updated MelfWare SVG logo and header/logo styling

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -5,25 +5,46 @@
   padding: 2rem 0;
 }
 
-#site-logo {
-  width: 200px;
+.site-header {
+  display: flex;
+  justify-content: center;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.site-header-inner {
+  width: 100%;
+  max-width: 1080px;
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.site-logo-img {
+  display: block;
   height: 80px;
+  width: auto;
   margin-bottom: 1rem;
   filter: drop-shadow(0 4px 8px var(--shadow-accent));
   transition: transform 0.3s ease;
 }
 
-#site-logo:hover {
+.site-logo-img:hover {
   transform: scale(1.05);
 }
 
-#site-tagline {
-  font-size: 1.1rem;
-  color: var(--text-color);
-  opacity: 0.8;
-  margin: 0.5rem 0 0 0;
-  font-weight: 300;
-  letter-spacing: 0.5px;
+body.dark .site-header {
+  border-bottom-color: #222;
+}
+
+body.dark .site-logo-img {
+  filter: drop-shadow(0 0 4px rgba(0, 0, 0, 0.5));
 }
 
 /* Enhanced welcome message */

--- a/static/img/melfware-logo.svg
+++ b/static/img/melfware-logo.svg
@@ -1,0 +1,45 @@
+<svg viewBox="0 0 460 110" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logoTitle logoDesc">
+  <title id="logoTitle">MelfWare</title>
+  <desc id="logoDesc">MelfWare - Intelligent Automation</desc>
+
+  <defs>
+    <linearGradient id="mw-blue-refined" x1="0%" y1="20%" x2="100%" y2="80%">
+      <stop offset="0%" stop-color="#0074FF"/>
+      <stop offset="50%" stop-color="#00B7FF"/>
+      <stop offset="100%" stop-color="#00E0FF"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Enhanced dot line (automation flow) -->
+  <g class="logo-dots" transform="translate(110,70)">
+    <circle cx="0" cy="0" r="3.2" fill="url(#mw-blue-refined)"/>
+    <circle cx="24" cy="0" r="3.2" fill="url(#mw-blue-refined)"/>
+    <circle cx="48" cy="0" r="3.2" fill="url(#mw-blue-refined)"/>
+    <circle cx="72" cy="0" r="3.2" fill="url(#mw-blue-refined)"/>
+    <circle cx="96" cy="0" r="3.2" fill="url(#mw-blue-refined)"/>
+    <circle cx="120" cy="0" r="3.2" fill="url(#mw-blue-refined)"/>
+    <circle cx="144" cy="0" r="3.2" fill="url(#mw-blue-refined)"/>
+    <circle cx="168" cy="0" r="3.2" fill="url(#mw-blue-refined)"/>
+  </g>
+
+  <!-- Refined wordmark -->
+  <text class="logo-wordmark"
+        x="105" y="55"
+        font-family="Segoe UI, system-ui, -apple-system, Arial, sans-serif"
+        font-weight="700"
+        font-size="38"
+        letter-spacing="0.5"
+        fill="url(#mw-blue-refined)">
+    MelfWare
+  </text>
+
+  <!-- Subtle tagline -->
+  <text class="logo-tagline"
+        x="108" y="95"
+        font-family="Segoe UI, system-ui, -apple-system, Arial, sans-serif"
+        font-size="13"
+        letter-spacing="1.3"
+        fill="#666666">
+    INTELLIGENT AUTOMATION
+  </text>
+</svg>

--- a/templates/home.html
+++ b/templates/home.html
@@ -37,9 +37,13 @@
   <main>
     <!-- Site Logo -->
     <section id="logo">
-      <img src="{{ get_url(path='images/melfware-logo-1.svg') }}" alt="MelfWare Logo" id="site-logo">
-      <h1 id="site-title">MelfWare</h1>
-      <p id="site-tagline">Intelligent Automation Solutions</p>
+      <a href="{{ get_url(path='/') }}" class="site-logo" aria-label="MelfWare - Home">
+        <img
+          src="{{ get_url(path='img/melfware-logo.svg') }}"
+          alt="MelfWare - Intelligent Automation"
+          class="site-logo-img"
+        >
+      </a>
     </section>
 
     <section id="info">


### PR DESCRIPTION
### Motivation

- Provide a final scalable SVG logo with improved visuals and accessibility so the header can use a responsive asset.
- Replace the previous fixed-size logo and separate title/tagline with a single logo asset for simpler header integration.
- Add CSS utility classes so the logo and header can be consistently styled and support dark mode.

### Description

- Added the new SVG asset at `static/img/melfware-logo.svg` containing gradients, accessibility elements (`role`, `title`, `desc`) and classes (`logo-dots`, `logo-wordmark`, `logo-tagline`).
- Updated `templates/home.html` to use an anchor logo markup linking to `/` and an `<img>` that references `img/melfware-logo.svg` with the `site-logo`/`site-logo-img` classes.
- Modified `static/custom.css` to introduce `.site-header`, `.site-header-inner`, `.site-logo`, and `.site-logo-img` rules and dark-mode tweaks, and removed the old `#site-logo`/`#site-tagline` styles.
- Created the `static/img` directory and added the new logo file and committed the changes.

### Testing

- No automated tests were run for these static asset and template changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69494ec6eedc832c8f8fc83b0ff21b25)