### PR TITLE
Add Train an AI Assistant project section and kickoff post

### DIFF
--- a/content/projects/train-an-ai-assistant/_index.md
+++ b/content/projects/train-an-ai-assistant/_index.md
@@ -1,0 +1,43 @@
++++
+title = "Train an AI Assistant"
+description = "Project hub for building a tailored AI assistant, from data curation to deployment-ready evaluation."
+sort_by = "date"
+template = "blog.html"
+page_template = "post.html"
+insert_anchor_links = "right"
+generate_feeds = true
+
+[extra]
+lang = "en"
+
+title = "Project Log"
+subtitle = "Designing, training, and validating a Codex-bootstrapped AI assistant."
+
+date_format = "%b %-d, %Y at %H:%M"
+
+categorized = false
+back_to_top = true
+toc = true
+comment = false
+copy = true
+
+outdate_alert = false
+outdate_alert_days = 30
+outdate_alert_text_before = "This article was last updated "
+outdate_alert_text_after = " days ago and may be out of date."
++++
+
+## Train an AI Assistant
+
+Welcome to the project space for creating a focused AI assistant tailored to real user workflows. This log tracks the full journey—from defining scope and curating examples to training, evaluating, and shipping iterative improvements.
+
+### What to expect here
+
+- **Design notes** on assistant behaviors, guardrails, and evaluation goals
+- **Training logs** that document data choices, prompt structures, and Codex-based scaffolding
+- **Playbooks** for testing, benchmarking, and monitoring quality over time
+- **Deployment considerations** for integrating the assistant into real tools and processes
+
+Follow along as we evolve from Codex prototypes to a reliable, production-ready assistant.
+
+---

--- a/content/projects/train-an-ai-assistant/getting-started-with-codex.md
+++ b/content/projects/train-an-ai-assistant/getting-started-with-codex.md
@@ -1,0 +1,77 @@
++++
+title = "Getting Started: Training an AI Assistant with Codex"
+date = 2025-12-30T11:22:40+00:00
+updated = 2025-12-30T11:22:40+00:00
+reading_time = 7
+description = "A practical first sprint to launch an AI assistant using Codex as the bootstrap model."
+keywords = ["AI assistant", "Codex", "prompt engineering", "evaluation", "training data"]
++++
+
+Training an AI assistant starts with clear intent and a rapid prototype. Codex is an excellent entry point because it can translate intent into structure—drafting prompts, scaffolding tools, and generating synthetic examples—so you can focus on defining quality.
+
+## Define the north star
+
+Begin by writing a one-paragraph charter that captures the assistant's audience, tone, and boundaries. Anchor every decision to this charter and keep it visible in your workspace. For this project, the assistant should be **practical, concise, and transparent about limitations**.
+
+## Capture seed workflows
+
+List 5–10 high-value tasks the assistant should excel at. For each task, collect:
+
+- **Inputs**: real user questions, context snippets, or configuration files
+- **Desired outputs**: an ideal answer with reasoning, references, and any safety constraints
+- **Failure modes**: what a bad answer looks like (hallucinations, missing steps, unsafe guidance)
+
+These examples become the first evaluation set. Even a small set is enough to guide Codex toward your expectations.
+
+## Use Codex to draft the baseline prompt
+
+Start with a system prompt that encodes the charter, tone, and formatting. Ask Codex to propose a structured prompt and then refine it manually. A simple template:
+
+```
+You are <assistant-name>, a concise AI assistant for <audience>.
+Always:
+- Ask for missing context in one sentence.
+- Show a numbered plan before long answers.
+- Cite tools or docs you relied on.
+Avoid speculation; say "I don't know" when uncertain.
+```
+
+Pair this with 3–5 **few-shot examples** built from your seed workflows. Codex can help draft these examples quickly—treat them as prototypes you will edit for accuracy and tone.
+
+## Build the first evaluation loop
+
+Before fine-tuning anything, run the baseline prompt against your seed examples:
+
+1. Call Codex with the prompt and each input.
+2. Score the responses manually using three criteria: **correctness**, **actionability**, and **safety**.
+3. Capture issues in a short log (one line per failure) to drive revisions.
+
+This loop surfaces where the prompt is unclear or where extra instructions are needed. Keep iterations tight: revise, rerun, and note the delta in quality.
+
+## Grow structured training data
+
+Once the baseline is stable, expand the dataset:
+
+- **Synthesize more examples with Codex**, then review them for accuracy.
+- **Source real transcripts** from support channels or internal documentation, anonymizing sensitive details.
+- **Label outputs** with short rationales (why the answer is good or bad). These labels make future fine-tuning or preference optimization faster.
+
+Aim for diversity: edge cases, multilingual queries, and safety-sensitive prompts.
+
+## Plan for fine-tuning and tooling
+
+When the prompt stabilizes and evaluations trend upward, plan the first model adaptation:
+
+- Start with **prompt-only** updates to keep iteration fast.
+- Move to **fine-tuning** once you have hundreds of high-quality, labeled interactions.
+- Introduce **tooling hooks** (search, calculators, policy checkers) and teach the model when to call them through explicit examples.
+
+Codex remains useful here: generate tool-call skeletons, draft unit tests for tool outputs, and propose guardrails that your application layer can enforce.
+
+## Next steps for this project
+
+- Publish the charter and initial prompt for peer review.
+- Automate the evaluation loop so every prompt change is scored against the seed set.
+- Define success metrics (e.g., 85% correctness on the seed set, zero unsafe outputs) before expanding the scope.
+
+This blogpost marks the starting point. With a Codex-bootstrapped baseline and a tight evaluation loop, we can iterate confidently toward a reliable, production-ready AI assistant.


### PR DESCRIPTION
## Summary
- add a new Projects subsection for the Train an AI Assistant effort with project-specific intro content
- publish the first project log detailing how to start training the assistant using Codex as the bootstrap model

## Testing
- zola build *(fails: zola not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b59b2118832c8b50010ce42c81cb)