### PR TITLE
Fix projects section listing

### DIFF
--- a/content/projects/The Home automation Robot Team
+++ b/content/projects/The Home automation Robot Team
@@ -1,4 +1,0 @@
-+++
-title = "The Home Automation Robot Team"
-date = 2025-06-07
-+++

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -1,8 +1,8 @@
 +++
 title = "Project Spotlights"
-description = "A blog showcasing interesting projects, case studies, and project management insights."
+description = "A curated list of active projects with quick links into their latest updates."
 sort_by = "date"
-template = "blog.html"
+template = "projects.html"
 page_template = "post.html"
 insert_anchor_links = "right"
 generate_feeds = true
@@ -26,3 +26,5 @@ outdate_alert_days = 12
 outdate_alert_text_before = "This article was last updated "
 outdate_alert_text_after = " days ago and may be out of date."
 +++
+
+Welcome to the Projects hub. Each spotlight below links to a dedicated project space with its own updates, logs, and artifacts. Dive in to follow along or pick up where the last milestone left off.

--- a/content/projects/home-automation-robot-team/_index.md
+++ b/content/projects/home-automation-robot-team/_index.md
@@ -1,0 +1,37 @@
++++
+title = "The Home Automation Robot Team"
+description = "Coordinating a fleet of small robots to handle household tasks through shared automation playbooks."
+date = 2025-06-07
+template = "blog.html"
+page_template = "post.html"
+insert_anchor_links = "right"
+generate_feeds = true
+sort_by = "date"
+
+[extra]
+lang = "en"
+
+title = "Home Automation Crew"
+subtitle = "From vacuuming to voice-assisted errands, tracking how miniature robots team up around the house."
+
+date_format = "%b %-d, %Y at %H:%M"
+
+categorized = false
+back_to_top = true
+toc = true
+comment = false
+copy = true
+
+outdate_alert = false
+outdate_alert_days = 30
+outdate_alert_text_before = "This article was last updated "
+outdate_alert_text_after = " days ago and may be out of date."
++++
+
+This project follows the journey of wiring together off-the-shelf gadgets, home-grown scripts, and a handful of small robots to act as a cohesive household team. Expect architecture notes, integration patterns, and sprint-sized experiments as the crew learns to schedule chores, share sensor data, and recover from mistakes without human babysitting.
+
+Early milestones focus on:
+
+- Designing a central “task board” that can negotiate jobs between robots and static automations.
+- Building reliable fallbacks so one robot can cover for another when something goes wrong.
+- Simplifying human inputs—short commands, NFC triggers, and voice prompts that get translated into repeatable routines.

--- a/content/projects/train-an-ai-assistant/_index.md
+++ b/content/projects/train-an-ai-assistant/_index.md
@@ -1,6 +1,7 @@
 +++
 title = "Train an AI Assistant"
 description = "Project hub for building a tailored AI assistant, from data curation to deployment-ready evaluation."
+date = 2025-12-30
 sort_by = "date"
 template = "blog.html"
 page_template = "post.html"

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -1,0 +1,132 @@
+{% extends "_base.html" %}
+{% import "macros/prose.html" as prose %}
+
+{% block page %}blog{% endblock page %}
+{% block lang %}{% if section.extra.lang %}{{ section.extra.lang }}{% else %}{{ section.lang }}{% endif %}{% endblock lang %}
+{% block title %}{{ section.title }}{% endblock title %}
+{% block desc %}
+  {% if section.description %}
+  <meta name="description" content="{{ section.description }}">
+  {% endif %}
+{% endblock desc %}
+
+{% block head %}
+{% if config.markdown.highlight_theme == "css" %}
+  {% if config.extra.force_theme == "dark" %}
+    <link id="hl" rel="stylesheet" type="text/css" href="{{ get_url(path='hl-dark.css') }}" />
+  {% else %}
+    <link id="hl" rel="stylesheet" type="text/css" href="{{ get_url(path='hl-light.css') }}" />
+  {% endif %}
+{% endif %}
+{% if section.extra.math %}
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        renderMathInElement(document.body, {
+            delimiters: [
+                { left: '$$', right: '$$', display: true },
+                { left: '$', right: '$', display: false },
+                { left: '\\(', right: '\\)', display: false },
+                { left: '\\[', right: '\\]', display: true }
+            ],
+            throwOnError: false
+        });
+    });
+</script>
+{% endif %}
+{% endblock head %}
+
+{% block content %}
+<div id="wrapper">
+  <main>
+    {{ prose::back_link() }}
+
+    <div class="section-title">
+      <h1>{{ section.extra.title | default(value=section.title) }}</h1>
+      {% if section.description %}
+      <p>{{ section.description }}</p>
+      {% endif %}
+    </div>
+
+    {% if section.content | trim != "" %}
+    <section class="prose">
+      {{ section.content | safe }}
+    </section>
+    {% endif %}
+
+    {% set date_format = section.extra.date_format | default(value="%b %-d, %Y") %}
+
+    {% set subsections = [] %}
+    {% for sub_path in section.subsections %}
+      {% set_global subsections = subsections | concat(with=[get_section(path=sub_path)]) %}
+    {% endfor %}
+    {% set subsections = subsections | sort(attribute="date") | reverse %}
+
+    {% if subsections | length > 0 %}
+    <section class="prose collection-wrapper">
+      {% for sub in subsections %}
+      <div class="collection card">
+        <div class="meta">
+          <a class="title" href="{{ sub.permalink }}">{{ sub.title }}</a>
+          {% if sub.date %}
+          <div class="date">{{ sub.date | date(format=date_format) }}</div>
+          {% endif %}
+        </div>
+        {% set summary = sub.extra.subtitle | default(value=sub.description) %}
+        {% if summary %}
+        <div class="subtitle">{{ summary }}</div>
+        {% endif %}
+        {% if sub.content %}
+        {% set excerpt = sub.content | striptags | truncate(length=260) %}
+        {% if excerpt | trim != "" %}
+        <div class="content">
+          <p>{{ excerpt }}</p>
+        </div>
+        {% endif %}
+        {% endif %}
+        <div class="tags">
+          <div>
+            <span>Explore</span>
+            <a href="{{ sub.permalink }}">View project updates</a>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </section>
+    {% endif %}
+
+    {% if section.pages | length > 0 %}
+    <section class="prose collection-wrapper">
+      {% for page in section.pages %}
+      <div class="collection card">
+        <div class="meta">
+          <a class="title" href="{{ page.permalink }}">{{ page.title }}</a>
+          {% if page.date %}
+          <div class="date">{{ page.date | date(format=date_format) }}</div>
+          {% endif %}
+        </div>
+        {% if page.description %}
+        <div class="subtitle">{{ page.description }}</div>
+        {% endif %}
+        {% if page.summary %}
+        <div class="content">
+          {{ page.summary | safe }}
+        </div>
+        {% else %}
+        {% set excerpt = page.content | striptags | truncate(length=260) %}
+        {% if excerpt | trim != "" %}
+        <div class="content">
+          <p>{{ excerpt }}</p>
+        </div>
+        {% endif %}
+        {% endif %}
+      </div>
+      {% endfor %}
+    </section>
+    {% endif %}
+  </main>
+</div>
+{% endblock content %}
+
+{% block script %}
+<script src="{{ get_url(path='js/lightense.min.js') }}"></script>
+{% endblock script %}


### PR DESCRIPTION
## Summary
- add a dedicated Projects template that renders section summaries, dates, and links to nested project spaces
- convert the Projects index into a populated hub page and add a proper Home Automation project subsection
- ensure project sections carry dates so the Projects listing can sort and display them reliably

## Testing
- ./scripts/test.sh *(fails: network access to GitHub/crates.io is blocked by a 403 CONNECT tunnel error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953f9d51494832c971de9aeef45f692)