### PR TITLE
fix: make project section dates valid

### DIFF
--- a/content/projects/home-automation-robot-team/_index.md
+++ b/content/projects/home-automation-robot-team/_index.md
@@ -1,7 +1,6 @@
 +++
 title = "The Home Automation Robot Team"
 description = "Coordinating a fleet of small robots to handle household tasks through shared automation playbooks."
-date = 2025-06-07
 template = "blog.html"
 page_template = "post.html"
 insert_anchor_links = "right"
@@ -10,6 +9,7 @@ sort_by = "date"
 
 [extra]
 lang = "en"
+date = 2025-06-07
 
 title = "Home Automation Crew"
 subtitle = "From vacuuming to voice-assisted errands, tracking how miniature robots team up around the house."

--- a/content/projects/train-an-ai-assistant/_index.md
+++ b/content/projects/train-an-ai-assistant/_index.md
@@ -1,7 +1,6 @@
 +++
 title = "Train an AI Assistant"
 description = "Project hub for building a tailored AI assistant, from data curation to deployment-ready evaluation."
-date = 2025-12-30
 sort_by = "date"
 template = "blog.html"
 page_template = "post.html"
@@ -10,6 +9,7 @@ generate_feeds = true
 
 [extra]
 lang = "en"
+date = 2025-12-30
 
 title = "Project Log"
 subtitle = "Designing, training, and validating a Codex-bootstrapped AI assistant."

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -59,7 +59,7 @@
     {% for sub_path in section.subsections %}
       {% set_global subsections = subsections | concat(with=[get_section(path=sub_path)]) %}
     {% endfor %}
-    {% set subsections = subsections | sort(attribute="date") | reverse %}
+    {% set subsections = subsections | sort(attribute="extra.date") | reverse %}
 
     {% if subsections | length > 0 %}
     <section class="prose collection-wrapper">
@@ -67,8 +67,9 @@
       <div class="collection card">
         <div class="meta">
           <a class="title" href="{{ sub.permalink }}">{{ sub.title }}</a>
-          {% if sub.date %}
-          <div class="date">{{ sub.date | date(format=date_format) }}</div>
+          {% set card_date = sub.date | default(value=sub.extra.date) %}
+          {% if card_date %}
+          <div class="date">{{ card_date | date(format=date_format) }}</div>
           {% endif %}
         </div>
         {% set summary = sub.extra.subtitle | default(value=sub.description) %}


### PR DESCRIPTION
## Summary
- move project section dates into `extra` metadata to satisfy Zola section schema
- adjust projects template to sort and display subsections using extra dates

## Testing
- zola build *(not run: zola not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953fc267fec832c8542f44ec9c62780)