### PR TITLE
fix: make back link path optional

### DIFF
--- a/templates/macros/prose.html
+++ b/templates/macros/prose.html
@@ -1,4 +1,4 @@
-{% macro back_link(path) %}
+{% macro back_link(path="") %}
 <header>
   <nav>
     <a id="back-link" href="#">← {{ config.extra.back_link_text }}</a>


### PR DESCRIPTION
## Summary
- allow the `back_link` macro override to accept an optional path argument so templates can call it without parameters
- unblock rendering of the projects section now that the macro matches current usage

## Testing
- ./bin/zola build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953fd44dabc832cbb8e5f57823aef38)