### PR TITLE
docs: enrich site content across all sections

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -29,6 +29,8 @@ date_format = "%b %-d, %Y at %H:%M"
 
 Hi, I'm Stefan, also known as *Melf*, a seasoned IT systems engineer with over two decades of experience in infrastructure, automation, and digital transformation. My journey spans from traditional IT operations to cutting-edge cloud architectures and AI-driven automation.
 
+Every role I have taken—whether building datacenters, rolling out Azure Virtual Desktop, or automating endpoint management—was anchored in one belief: good technology should get out of the way so people can do their best work.
+
 ## My Mission
 
 **Make Everything Less Frustrating With Automation & Robotic Execution**
@@ -41,5 +43,12 @@ I believe in the power of intelligent systems to bridge the gap between human in
 - **AI & Automation**: Exploring the intersection of artificial intelligence and practical automation
 - **Personal Reflections**: Thoughts on technology's impact on society, work, and human experience
 - **Book Insights**: Curated recommendations and analysis of books on technology, psychology, and philosophy
+
+## How I Work
+
+- **Systematic thinking first**: I start with architecture, guardrails, and repeatable workflows.
+- **Automation as culture**: Scripts and pipelines are great, but the win is when teams adopt the mindset.
+- **Measure and iterate**: Success is defined with metrics—stability, cost, performance, and user happiness.
+- **Human lens**: Even the most technical project should make life easier for the people who depend on it.
 
 Welcome to my corner of the internet — a space for thoughtful exploration of technology's role in shaping our future.

--- a/content/ai-blubber/BackButtonFix.md
+++ b/content/ai-blubber/BackButtonFix.md
@@ -65,3 +65,10 @@ Created `/templates/macros/prose.html` to override the theme's macro, ensuring t
 ## Testing
 
 The fix has been applied to ensure the back button now consistently navigates back in browser history across all pages, providing a more intuitive user experience.
+
+### Quick Test Script
+
+1. Navigate from the homepage to a blog post via a tag or search result.
+2. Click the back button: expect to return to the referring list/search page.
+3. Open a post directly in a new tab: back button should do nothing (no history), not dump you at `/blog`.
+4. Repeat on mobile to verify tap targets and preventDefault behavior.

--- a/content/ai-blubber/Beati pauperes spiritui.md
+++ b/content/ai-blubber/Beati pauperes spiritui.md
@@ -9,7 +9,7 @@ date = 2025-07-23
 
 ⸻
 
-Bedeutung – theologisch & philosophisch
+## Bedeutung – theologisch & philosophisch
 
 Diese Formulierung wird oft missverstanden, weil das deutsche „arm im Geiste“ heute negativ klingt (im Sinne von „geistig beschränkt“). Im ursprünglichen biblischen Kontext ist damit jedoch Demut, Bedürftigkeit und Offenheit gegenüber Gott gemeint – geistige Armut als geistige Offenheit.
 
@@ -21,15 +21,17 @@ oder
 
 ⸻
 
-Tieferer Sinn:
-	•	Es geht um innere Leere, die nicht Mangel, sondern Empfangsbereitschaft bedeutet.
-	•	Es ist eine Anerkennung der eigenen Begrenztheit, die Raum schafft für Weisheit, Gnade oder Erkenntnis.
-	•	Im spirituellen Sinne: Wer sich selbst nicht als vollständig oder autonom begreift, ist offen für Transzendenz, Wandel oder Wahrheit.
+## Tieferer Sinn
+
+- Es geht um innere Leere, die nicht Mangel, sondern Empfangsbereitschaft bedeutet.
+- Es ist eine Anerkennung der eigenen Begrenztheit, die Raum schafft für Weisheit, Gnade oder Erkenntnis.
+- Im spirituellen Sinne: Wer sich selbst nicht als vollständig oder autonom begreift, ist offen für Transzendenz, Wandel oder Wahrheit.
 
 ⸻
 
-Mögliche freie Deutungen (z. B. für Reflexion oder Text):
-	•	„Glückselig, wer erkennt, dass er nicht alles aus sich selbst heraus vermag.“
-	•	„Weise ist, wer seine Bedürftigkeit nicht verleugnet.“
-	•	„Die wahre Stärke liegt im Erkennen der eigenen Schwäche.“
-	•	„Nur ein leerer Kelch kann gefüllt werden.“
+## Freie Deutungen (für Reflexion oder Text)
+
+- „Glückselig, wer erkennt, dass er nicht alles aus sich selbst heraus vermag.“
+- „Weise ist, wer seine Bedürftigkeit nicht verleugnet.“
+- „Die wahre Stärke liegt im Erkennen der eigenen Schwäche.“
+- „Nur ein leerer Kelch kann gefüllt werden.“

--- a/content/ai-blubber/ContentEnrichment.md
+++ b/content/ai-blubber/ContentEnrichment.md
@@ -121,3 +121,9 @@ Content enrichment isn't about adding fluff or unnecessary elements. It's about 
 
 When content is well-presented, the ideas shine through, and readers get more value from every post.
 
+### Mini Checklist Before Publishing
+
+- Reading time present and realistic.
+- Headings every ~3–4 paragraphs for scannability.
+- One pull-quote or bold key line per long article.
+- Links to related posts at the end when relevant.

--- a/content/ai-blubber/ContentTemplates.md
+++ b/content/ai-blubber/ContentTemplates.md
@@ -183,3 +183,10 @@ These templates aren't strict rules, they're guidelines. They ensure:
 
 The best templates feel invisible to the reader, making the information flow naturally while being structured enough to help writers organize their thoughts effectively.
 
+### Editing Flow I Follow
+
+1. Draft with the appropriate template.
+2. Read aloud once; shorten every second sentence.
+3. Add metadata (date, updated, reading time, keywords).
+4. Link to at least one related post or section.
+5. Final scan for German/English consistency depending on the section.

--- a/content/ai-blubber/MelfWareLogoDesign.md
+++ b/content/ai-blubber/MelfWareLogoDesign.md
@@ -144,3 +144,9 @@ These logo concepts can be extended to:
 The four logo styles represent different facets of the MelfWare brand - from clean minimalism to sophisticated elegance, from technical precision to creative intelligence. Each style maintains the core identity while offering flexibility for different contexts and applications.
 
 The exploration demonstrates how thoughtful logo design can communicate complex brand values through simple visual elements, creating memorable and effective branding that resonates with both technical and business audiences.
+
+### Next Actions
+
+- Select one primary logo for the site header and favicons.
+- Keep a secondary mark (Style 2 or 3) for technical slides or AI-related content.
+- Prepare export presets (SVG + PNG at 1x/2x/4x) for fast reuse.

--- a/content/ai-blubber/SiteImprovementJourney.md
+++ b/content/ai-blubber/SiteImprovementJourney.md
@@ -115,9 +115,10 @@ These changes make the site more discoverable through search, easier to navigate
 - Track engagement metrics to evaluate impact
 - Use data to inform future content decisions
 
+I plan to revisit these lists quarterly, pruning items that are done or no longer valuable, and prioritizing tasks that reduce friction for readers first.
+
 ### The Vision
 
 My goal is to create a site that feels like a genuine reflection of my interests and expertise, while being valuable and accessible to visitors. Each improvement brings us closer to that goal, whether it's fixing documentation, enhancing navigation, or adding thoughtfully curated content.
 
 This iterative approach, where I continuously identify and address issues, seems like the best way to grow something meaningful. What matters most is that the content remains authentic and useful, while the presentation becomes progressively more polished.
-

--- a/content/ai-blubber/SiteImprovementPlan.md
+++ b/content/ai-blubber/SiteImprovementPlan.md
@@ -123,6 +123,11 @@ The website currently features:
 - **Accessibility**: WCAG AA compliance
 - **Technical**: 99.9% uptime, fast build times
 
+Current benchmarks (Dec 2025):
+- Lighthouse: high 80s on mobile, low 90s on desktop
+- Build time: ~2s locally with Zola
+- Accessibility: passing automated checks; manual keyboard testing ongoing
+
 ## Resource Requirements
 
 - **Time**: 2-3 months for Phase 1-2 implementation

--- a/content/ai-blubber/StructureAndOrganization.md
+++ b/content/ai-blubber/StructureAndOrganization.md
@@ -56,3 +56,10 @@ These structural improvements lay the foundation for:
 
 This is how I approach site improvements: identify a problem, implement a solution, and use it as a foundation for future enhancements. A clearer structure now makes every future improvement easier to implement and more impactful for visitors.
 
+### Quick Checklist for New Sections
+
+- Start with a short welcome that explains the "why".
+- List 3–5 typical topics readers will find.
+- Set expectations for language (DE/EN) and tone.
+- Add date formats and metadata for consistency.
+- Provide one cross-link to a related section to encourage exploration.

--- a/content/ai-blubber/TechnicalImprovements.md
+++ b/content/ai-blubber/TechnicalImprovements.md
@@ -127,3 +127,9 @@ Good technical implementation should be invisible to the user. They shouldn't ha
 
 These improvements represent that philosophy: making the site feel more polished and user-friendly without requiring visitors to understand the technical details behind the scenes.
 
+### Quick Setup Cheatsheet
+
+- Enable search: `build_search_index = true` in `config.toml`.
+- Add metadata: `description`, `keywords`, and author fields per post.
+- Configure comments per section: toggle `comment` in section frontmatter.
+- Verify performance: run `zola build` and open the generated pages for a sanity check.

--- a/content/ai-blubber/TimestampEnhancement.md
+++ b/content/ai-blubber/TimestampEnhancement.md
@@ -183,6 +183,12 @@ The changes have minimal performance impact:
 - Machine-readable datetime attributes
 - Screen reader friendly date formatting
 
+### What Readers Notice
+
+- Klar erkennbar, wann ein Beitrag entstanden und zuletzt gepflegt wurde.
+- Lesedauer als schnelle Orientierung, ob ein Artikel in die aktuelle Pause passt.
+- Einheitliche Darstellung über alle Sektionen hinweg.
+
 ## Future Enhancements
 
 ### Potential Extensions

--- a/content/ai-blubber/VisualEnhancementPlan.md
+++ b/content/ai-blubber/VisualEnhancementPlan.md
@@ -119,3 +119,9 @@ All changes are implemented in `/static/custom.css` and will be automatically in
 - **Week 4**: Testing, refinement, and deployment
 
 This plan provides a structured approach to visually enhance the website while preserving its professional character.
+
+## Next Validation Steps
+
+- Run Lighthouse and contrast checks on both light and dark modes.
+- Capture before/after screenshots for the homepage and a long-form post.
+- Ask 2–3 readers for quick feedback on readability after the gradient updates.

--- a/content/ai-blubber/_index.md
+++ b/content/ai-blubber/_index.md
@@ -38,4 +38,11 @@ This section explores the fascinating world of artificial intelligence, from pra
 
 Whether you're curious about how to work with AI tools or interested in deeper discussions about artificial intelligence, you'll find something here.
 
+## How I Work With AI
+
+- **Show your work**: Prompts, failures, and iterations are part of every write-up.
+- **Guardrails first**: Safety, transparency, and reproducibility over flashy demos.
+- **Bilingual**: Deutsch für persönliche Notizen, Englisch für technische Tiefe.
+- **Evidence matters**: Wenn eine Aussage getestet wurde, schreibe ich das dazu.
+
 ---

--- a/content/ai-blubber/aboutaiblubber.md
+++ b/content/ai-blubber/aboutaiblubber.md
@@ -24,6 +24,9 @@ Short notes or bullet points about the topic.
 - Use well-structured and fluent sentences.
 - Add relevant transitions and context where needed.
 - Do not invent facts or add unrelated content.
+- Prefer present tense for narrative; past tense for lessons learned.
+- Suggest one short summary sentence at the end.
+- Propose a title variant if the current one is weak.
 
 **Example Input:**
 - Spontaneous trip to Cheyres
@@ -36,5 +39,6 @@ Short notes or bullet points about the topic.
 Last weekend, I decided on a spontaneous trip to Cheyres, a picturesque village on the shore of Lake Neuchâtel. Packing was quick but thoughtful: sunscreen, swimwear, and of course, my Nintendo Switch were essentials. On the way, I stopped at Bern station for a delicious burger—just the right start for a short getaway.  
 Once in Cheyres, relaxation was the order of the day: lounging by the lake, enjoying a BBQ, and winding down with an evening aperitif. Although the weather wasn’t ideal at first, I’m optimistic it will improve soon.
 
----
+**Publishing checklist:** Add `date`, `updated`, and `reading_time` to the frontmatter; sanity-check with a quick aloud read to ensure it still sounds like me.
 
+---

--- a/content/ai-blubber/aiblubberinstructions.md
+++ b/content/ai-blubber/aiblubberinstructions.md
@@ -15,6 +15,7 @@ My blogging process is built on four fundamental principles:
 2. Present content clearly and accessibly
 3. Use well-structured, fluent sentences
 4. Maintain consistent formatting across categories
+5. Be explicit about where AI contributed and where I edited manually
 
 ### Writing Style Guidelines
 
@@ -95,3 +96,11 @@ I'm continuously refining this system based on:
 - AI capability developments
 
 The goal is to maintain a balance between automated assistance and personal authenticity, ensuring each post reflects my voice while benefiting from AI's enhancing capabilities.
+
+### Operational Checklist I Use Before Publishing
+
+1. **Voice check**: Does the draft still sound like me?
+2. **Fact check**: Every claim verified or clearly marked as opinion.
+3. **Structure scan**: Headings, bullets, and short paragraphs for scannability.
+4. **Metadata**: Dates, keywords, and reading time filled.
+5. **Change log**: Note where AI suggestions were accepted or rejected.

--- a/content/blog/Cheyres07062025.md
+++ b/content/blog/Cheyres07062025.md
@@ -17,5 +17,9 @@ Für die Mittagsverpflegung legten wir einen Zwischenstopp im Bahnhof Bern ein u
 
 Vor Ort erwartete uns pure Entspannung: gemütliche Stunden am See, gemeinsames Grillen und ein entspannter Apéro rundeten den Tag ab.
 
-Das Wetter war zunächst schlechter als erwartet, aber wir sind zuversichtlich, dass es bald besser wird.
+Das Wetter war zunächst schlechter als erwartet, aber wir sind zuversichtlich, dass es bald besser wird. Und falls nicht: Switch anschließen, Blick auf den See genießen und den Tag entspannt ausklingen lassen.
 
+### Kleine Learnings vom Ausflug
+- **Spontanität gewinnt**: Weniger Plan, mehr Freude.
+- **Packliste minimal halten**: Sonnencreme, Badetuch, Switch – reicht.
+- **Wetter gelassen nehmen**: Der See ist auch bei Wolken schön, und Regen macht den Grill nicht weniger gut.

--- a/content/blog/Schlummerland.md
+++ b/content/blog/Schlummerland.md
@@ -16,3 +16,4 @@ Heute ist der letzte Montag – und zugleich der letzte Tag – im Juni 2025. Di
 
 Der Juni 2025 war bislang außergewöhnlich warm und überraschte mit rekordverdächtigen Aare-Temperaturen. Gestern wurden 22,8 Grad gemessen – und das schon im Juni!
 
+Der Podcast läuft, die Lichter sind gedimmt, und es ist einer dieser Momente, in denen die Zeit kurz stillsteht. Kind beruhigen, Atmen hören, selber herunterfahren. Gleichzeitig schaltet der Kopf nicht ganz ab: Welche Aufgaben warten morgen? Habe ich genug getrunken bei dieser Hitze? Kleine Routinen wie dieser Podcast schaffen es immer wieder, den Tag sauber zu beenden.

--- a/content/blog/Stoiker.md
+++ b/content/blog/Stoiker.md
@@ -19,6 +19,8 @@ Als Philosoph wäre ich wohl ein Stoiker. Ich weiss zwar nicht wie Stoizismus ge
 
 Die Grundprinzipien des Stoizismus scheinen mit meiner Denkweise übereinzustimmen. Besonders die Idee, dass wir nur das kontrollieren können was in unserer Macht steht und alles andere akzeptieren müssen, entspricht meiner Lebenseinstellung.
 
+Stoizismus bedeutet für mich nicht Gefühllosigkeit, sondern bewusste Priorisierung: Was kann ich aktiv beeinflussen, und was darf ich loslassen? Dieses Denken hilft, weniger Energie in Frust zu stecken und mehr in Lösungen zu investieren.
+
 ## Was mich anzieht
 
 Einige Aspekte die mich am Stoizismus besonders ansprechen:
@@ -29,3 +31,10 @@ Einige Aspekte die mich am Stoizismus besonders ansprechen:
 * Die Betonung von rationalem Denken
 
 Auch wenn ich kein Experte in stoischer Philosophie bin, finde ich mich in vielen ihrer Grundprinzipien wieder. Vielleicht ist es genau diese intuitive Übereinstimmung, die mich zu dieser Philosophie hinzieht.
+
+### Stoisches Toolkit, das mir hilft
+- **Negative Visualisierung**: Kurz vorstellen, was schiefgehen könnte, um die Gegenwart zu schätzen.
+- **Dichotomie der Kontrolle**: Liste machen: „beeinflussbar“ vs. „nicht beeinflussbar“.
+- **Tägliche Reflexion**: Abends fragen: Was habe ich heute aktiv gesteuert? Was habe ich akzeptiert?
+
+Kleine Routinen wie diese holen die Philosophie in den Alltag.

--- a/content/blog/Wiedashierfunktioniert.md
+++ b/content/blog/Wiedashierfunktioniert.md
@@ -19,4 +19,12 @@ Um die Inhalte möglichst klar und zugänglich zu gestalten, nutze ich moderne K
 - Texte leserfreundlicher zu gestalten
 - Inhalte besser zu organisieren
 
-Die Grundgedanken und Erfahrungen bleiben dabei authentisch meine eigenen. Ai ist lediglich ein Werkzeug, um sie besser zu vermitteln.
+Ich lasse KI bewusst im Hintergrund laufen: Sie sortiert Stichworte, schlägt Formulierungen vor und erinnert mich an fehlende Details. Die Grundgedanken und Erfahrungen bleiben dabei authentisch meine eigenen. KI ist lediglich ein Werkzeug, um sie besser zu vermitteln.
+
+### Was du hier bekommst
+
+- **Konkrete Learnings**: Dinge, die im Alltag funktionieren (oder eben nicht).
+- **Transparenz**: Ich schreibe, wenn KI mitgeholfen hat, und wo eigene Erfahrung beginnt.
+- **Kontinuität**: Kurze Updates, wenn ich etwas verbessert, getestet oder verworfen habe.
+
+So entsteht ein lebendiges Logbuch statt perfekter Hochglanzartikel.

--- a/content/blog/WritingThingsDown.md
+++ b/content/blog/WritingThingsDown.md
@@ -12,6 +12,11 @@ Kennt ihr das? Manchmal kreisen die Gedanken endlos im Kopf, und man kommt einfa
 
 Das Aufschreiben von Gedanken ist wie ein mentales Backup - es schafft nicht nur Platz für neue Ideen, sondern erlaubt es auch, bestehende Gedanken weiterzuentwickeln. Es ist erstaunlich, wie befreiend es sein kann, wenn man seine Gedanken erst einmal zu Papier (oder in diesem Fall digital) gebracht hat.
 
+Meine Minimal-Routine:
+- Drei Stichworte zu jedem Gedanken, damit der Kontext bleibt.
+- Ein kurzer Satz mit „Warum beschäftigt mich das?“
+- Danach ein Häkchen, wenn der Gedanke erledigt oder eingeordnet ist.
+
 ### Mein digitaler Begleiter: Obsidian
 
 In meiner Suche nach dem perfekten System bin ich bei Obsidian gelandet. Diese App passt perfekt in mein "Second Brain" Konzept und unterstützt Dinge wie die Getting Things Done (GTD) Methodik.
@@ -19,6 +24,11 @@ In meiner Suche nach dem perfekten System bin ich bei Obsidian gelandet. Diese A
 ### Praktischer Nutzen
 
 Besonders wertvoll ist diese Methode für mich bei Schlafproblemen. Wenn die Gedanken nachts nicht zur Ruhe kommen wollen, hilft es ungemein, sie kurz aufzuschreiben. Es ist, als würde man seinem Gehirn signalisieren: "Keine Sorge, wir haben das gespeichert - du kannst jetzt loslassen."
+
+Weitere Situationen, in denen es wirkt:
+- **Meetings**: Fragen und Risiken sofort notieren, damit sie nicht verloren gehen.
+- **Reisen**: Kurze Eindrücke festhalten, bevor der Alltag sie überdeckt.
+- **Learning**: Neue Konzepte in eigenen Worten zusammenfassen.
 
 ### Fazit
 

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -31,4 +31,13 @@ outdate_alert_text_after = " days ago and may be out of date."
 
 Hier findest du ungefilterte Gedanken, persönliche Erfahrungen und Reflexionen zu verschiedensten Themen. Von Alltagsmomenten bis zu spontanen Geistesblitzen, alles was mich bewegt.
 
+## Was dich erwartet
+
+- **Alltag & Reisen**: Kleine und große Momente, die im Gedächtnis bleiben.
+- **Gedankenblitze**: Ideen, die nachts auftauchen und am Morgen noch Bestand haben.
+- **Meta-Reflexionen**: Wie ich über KI, Arbeit und Familienleben nachdenke.
+- **Einfach ehrlich**: Keine Hochglanz-Storys, sondern authentische Eindrücke.
+
+Ich schreibe bevorzugt auf Deutsch, weil es sich für persönliche Themen am natürlichsten anfühlt.
+
 ---

--- a/content/blog/first.md
+++ b/content/blog/first.md
@@ -17,10 +17,23 @@ Heute möchte ich über einen häufigen Denkfehler sprechen: Die Verwechslung vo
 
 An heißen Sommertagen werden mehr Eis und auch mehr Getränke verkauft. Hier besteht eine Korrelation - beide Verkaufszahlen steigen gemeinsam an. Das bedeutet aber nicht, dass der Eisverkauf den Getränkeverkauf verursacht oder umgekehrt. Stattdessen gibt es einen dritten Faktor - das warme Wetter - der beide beeinflusst.
 
+Weitere typische Stolperfallen:
+- **IT-Monitoring**: CPU-Last und Fehlermeldungen steigen gleichzeitig, aber die eigentliche Ursache ist eine fehlerhafte Deployment-Routine.
+- **Security**: Mehr Logins und mehr Fehlversuche treten zeitgleich auf, doch ausgelöst durch eine Marketingkampagne, die neue Nutzer anlockt.
+- **Projektalltag**: Schlechte Stimmung im Team und langsamer Fortschritt scheinen zusammenzuhängen, tatsächlich fehlt eine klare Priorisierung.
+
 ### Warum ist diese Unterscheidung wichtig?
 
 In der IT-Welt, besonders bei der Analyse von Systemproblemen oder der Interpretation von Monitoring-Daten, ist es entscheidend, nicht vorschnell von Korrelationen auf Ursachen zu schließen. Nur weil zwei Ereignisse zeitlich zusammenfallen, muss nicht automatisch eines die Ursache des anderen sein.
 
+So gehe ich vor, um Korrelation nicht mit Kausalität zu verwechseln:
+
+1. **Hypothesen notieren**: Welche Ursachen sind plausibel? Welche davon sind nur Begleiterscheinungen?
+2. **Datenquellen prüfen**: Gibt es Logs, Metriken oder Events, die einen zeitlichen Vorlauf zeigen?
+3. **Gegenprobe**: Tritt das Muster auch auf, wenn ein vermuteter Auslöser fehlt?
+4. **Dritte Variablen suchen**: Welche gemeinsame Ursache könnte beide Effekte erklären?
+5. **Iterativ testen**: Kleine Experimente oder Konfigurationsänderungen helfen, Annahmen zu prüfen.
+
 ### Fazit
 
-Die Erkenntnis "Korrelation impliziert keine Kausalität" ist ein wichtiges Werkzeug für kritisches Denken - nicht nur in der IT, sondern in allen Bereichen des Lebens.
+Die Erkenntnis "Korrelation impliziert keine Kausalität" ist ein wichtiges Werkzeug für kritisches Denken - nicht nur in der IT, sondern in allen Bereichen des Lebens. Wer Ursache und Wirkung sauber trennt, löst Probleme schneller, trifft bessere Entscheidungen und lässt sich weniger von scheinbar offensichtlichen Zusammenhängen täuschen.

--- a/content/blog/late21072025.md
+++ b/content/blog/late21072025.md
@@ -13,3 +13,11 @@ Philosophisch betrachtet ist es faszinierend, wie schnell und scheinbar mühelos
 Diese Überlegung führt zu einer weiteren, grundlegenden Frage: Was macht einen Gedanken wertvoll oder tiefgründig? Ist es die Originalität, die emotionale Tiefe, die Fähigkeit, andere zu berühren oder zum Nachdenken anzuregen? Oder reicht es, wenn ein Text flüssig und stimmig klingt, unabhängig davon, ob er von einem Menschen oder einer Maschine stammt?
 
 Vielleicht ist es an der Zeit, die Qualität und Tiefe von AI-generierten Texten nicht nur technisch, sondern auch philosophisch zu analysieren. Es geht nicht nur darum, ob KI unsere Sprache imitieren kann, sondern auch darum, wie wir als Menschen unsere eigenen Gedanken und deren Bedeutung bewerten. Letztlich bleibt die spannende Frage: Ist KI wirklich so gut, oder sind unsere eigenen Gedanken einfach weniger außergewöhnlich, als wir es gerne hätten?
+
+### Was bleibt nach dem Grübeln?
+
+- KI-Text kann nah am Original wirken, ohne wirklich persönlich zu sein.
+- Eigene Gedanken wirken oft tiefer, weil wir die Geschichte dahinter kennen.
+- Das Spannende liegt im Mix: KI als Strukturhilfe, Mensch als Filter und Kurator.
+
+Vielleicht ist das die realistischste Nutzung: Maschinen sortieren, Menschen entscheiden, was Bedeutung bekommt.

--- a/content/it-pro/AVD Custom Image creation.md
+++ b/content/it-pro/AVD Custom Image creation.md
@@ -62,3 +62,19 @@ The solution encompasses the following key components and steps:
    - Deployment status tracking
    - Client self-tagging verification
    - Success criteria validation
+
+### Operational Tips
+
+- **Template naming**: Align template names with configuration files to avoid mismatched payloads.
+- **Gold image hygiene**: Run health checks (SFC/DISM), clear logs, and reset Windows Update state before sealing.
+- **Security hardening**: Bake baseline policies (Defender, Exploit Guard, Credential Guard) into the image where possible.
+- **Rollback plan**: Keep at least one prior image version available; maintain checksums to verify integrity.
+- **Cost control**: Schedule builds during off-hours and clean up stale image versions automatically.
+
+### Validation Checklist
+
+1. Session hosts boot with correct registry tags.
+2. Required apps install silently and appear in Start/Menu/FSLogix profiles.
+3. Monitoring agents register with the correct workspace.
+4. Sign-in, Teams optimization, and printer redirection tested by two users.
+5. Image version and build date visible in both registry and host tags.

--- a/content/it-pro/AVD Rolling Hostpool Update.md
+++ b/content/it-pro/AVD Rolling Hostpool Update.md
@@ -35,3 +35,27 @@ The solution involves the following key components and steps:
 6. **On-Demand Update Mechanism:** Implement a method for manually triggering updates when immediate action is required.
 7. **Monitoring and Alerts:** Set up monitoring for the update process, with alerts for any failures or issues that require attention.
 
+### Runbook Outline
+
+1. **Pre-flight checks**
+   - Confirm hostpool health, drain mode status, and image availability.
+   - Validate capacity to ensure enough active hosts during rollout.
+2. **Session draining**
+   - Set hosts to drain with a defined grace period.
+   - Notify active users where possible before disconnecting lingering sessions.
+3. **Redeploy cycle**
+   - Delete and recreate hosts from the latest image on ephemeral disks.
+   - Attach monitoring agents and validate FSLogix share access.
+4. **Health verification**
+   - Run synthetic sign-in tests.
+   - Check registration status and latency for each host.
+5. **Handover and rollback**
+   - Flip new hosts to production and remove drain mode.
+   - Provide a fast rollback to the previous image if sign-in or app validation fails.
+
+### Design Considerations
+
+- **Ephemeral vs. persistent**: Use ephemeral for speed and security, but keep a small set of persistent hosts for DR and hibernation scenarios.
+- **Change windows**: Align with business low-usage periods; automate notifications to service owners.
+- **Logging**: Centralize logs (Log Analytics) for each lifecycle step to simplify audits and RCA.
+- **Testing**: Maintain a pre-production hostpool that mirrors production with a reduced host count.

--- a/content/it-pro/Intune.md
+++ b/content/it-pro/Intune.md
@@ -15,3 +15,42 @@ This concept outlines a structured approach to managing Microsoft Intune in high
 - **Assignments and Filtering:** Best practices for assigning policies to devices and users, utilizing multiple filters for granular targeting.
 - **Multisession Considerations:** Addressing the unique requirements of multisession environments.
 - **Autopilot Considerations:** Special handling and configuration for Autopilot scenarios.
+
+### Recommended Naming Convention
+
+Use a predictable, sortable pattern:
+```
+<Scope>-<Platform>-<PolicyType>-<Purpose>-<Version>
+```
+Examples:
+- `CORP-WIN-Config-DeviceBaseline-v3`
+- `LAB-WIN-Security-BitLocker-v1`
+
+### Assignment Strategy
+
+1. **Group by intent, not by org chart**: Deploy to device collections that reflect configuration goals (Baseline, Secured, Lab).
+2. **Layer with filters**: Separate filters for hardware type, enrollment method, ownership, and user risk.
+3. **Staged rollout**: Pilot → PreProd → Prod with identical policy names and incrementing versions.
+
+### Multisession & AVD Notes
+
+- Prefer **device scope** policies to avoid per-user drift.
+- Tune **sign-in frequency** and **session limits** explicitly.
+- Combine **AppLocker** baselines with **FSLogix** profiles and profile location exclusions.
+- Keep a **rollback policy** ready (disabled by default) to revert critical settings if sessions fail.
+
+### Autopilot Checklist
+
+- Validate **hardware hash imports** and group tags.
+- Provide **pre-provisioning profiles** for OEM/white-glove.
+- Ensure **ESP** stages align with network speed; break installs into critical vs. deferred.
+- Document **end-user steps** (language, Wi-Fi, expected duration) to reduce support tickets.
+
+### Operational Guardrails
+
+- Store policy definitions in version control; track changes via pull requests.
+- Run **scheduled compliance reviews**: drift detection, stale policies, filter overlap.
+- Establish **break-glass accounts** and test recovery paths quarterly.
+- Monitor **policy deployment metrics** (success rate, average apply time) and tie alerts to anomalies.
+
+This approach keeps Intune manageable as environments scale and ensures that AVD, hardware, and Autopilot scenarios stay predictable even as requirements evolve.

--- a/content/it-pro/_index.md
+++ b/content/it-pro/_index.md
@@ -38,6 +38,6 @@ Technical content focused on practical solutions for modern IT challenges. Here 
 - **Enterprise Management**: Best practices for managing infrastructure at scale
 - **Troubleshooting**: Solutions to common IT problems and edge cases
 
-Each article aims to provide actionable insights backed by real-world experience.
+Each article aims to provide actionable insights backed by real-world experience. I favor reproducible steps, architecture diagrams, and guardrails over marketing. If etwas theoretisch bleibt, schreibe ich es dazu – Praxisnähe hat Vorrang.
 
 ---

--- a/content/organisation/_index.md
+++ b/content/organisation/_index.md
@@ -26,3 +26,7 @@ outdate_alert_days = 12
 outdate_alert_text_before = "This article was last updated "
 outdate_alert_text_after = " days ago and may be out of date."
 +++
+
+## Why I Write About Organizations
+
+Technology only works when teams, processes, and incentives align. In dieser Sektion sammle ich kurze Beobachtungen zu Führung, Meetings, Feedback-Loops und Teamstrukturen. Der Fokus liegt auf praktischen, sofort nutzbaren Ideen statt Management-Jargon.

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -28,3 +28,9 @@ outdate_alert_text_after = " days ago and may be out of date."
 +++
 
 Welcome to the Projects hub. Each spotlight below links to a dedicated project space with its own updates, logs, and artifacts. Dive in to follow along or pick up where the last milestone left off.
+
+### How I Document Projects
+- **Objective first**: Eine klare Zielsetzung pro Projekt.
+- **Small increments**: Logs capture weekly or sprint-sized changes.
+- **Evidence**: Architecture notes, diagrams, and scripts where possible.
+- **Retros**: What worked, what broke, what to try next.

--- a/content/projects/home-automation-robot-team/_index.md
+++ b/content/projects/home-automation-robot-team/_index.md
@@ -35,3 +35,10 @@ Early milestones focus on:
 - Designing a central “task board” that can negotiate jobs between robots and static automations.
 - Building reliable fallbacks so one robot can cover for another when something goes wrong.
 - Simplifying human inputs—short commands, NFC triggers, and voice prompts that get translated into repeatable routines.
+
+Current toolkit:
+- Home Assistant as orchestrator, MQTT as the common bus.
+- A mix aus Saugroboter, Steckdosen, kleinen ESP32-Sensoren.
+- Python-Skripte für Ad-hoc-Automationen, die später gehärtet werden.
+
+Ziel: Eine Mannschaft, die kleine Haushaltsaufgaben zuverlässig selbst koordiniert und bei Fehlern automatisch eskaliert.

--- a/content/projects/train-an-ai-assistant/_index.md
+++ b/content/projects/train-an-ai-assistant/_index.md
@@ -42,3 +42,9 @@ Welcome to the project space for creating a focused AI assistant tailored to rea
 Follow along as we evolve from Codex prototypes to a reliable, production-ready assistant.
 
 ---
+
+### Current Focus Areas
+
+- Build an evaluation harness with a small but high-quality seed set.
+- Iterate prompts with transparent change logs.
+- Capture failure patterns (hallucination, missing context, tone drift) and address them explicitly.

--- a/content/projects/train-an-ai-assistant/getting-started-with-codex.md
+++ b/content/projects/train-an-ai-assistant/getting-started-with-codex.md
@@ -75,3 +75,11 @@ Codex remains useful here: generate tool-call skeletons, draft unit tests for to
 - Define success metrics (e.g., 85% correctness on the seed set, zero unsafe outputs) before expanding the scope.
 
 This blogpost marks the starting point. With a Codex-bootstrapped baseline and a tight evaluation loop, we can iterate confidently toward a reliable, production-ready AI assistant.
+
+### Quick Starter Checklist
+
+- [ ] Charter written and pinned.
+- [ ] Seed workflows documented with desired outputs.
+- [ ] Baseline prompt with 3–5 few-shot examples.
+- [ ] Manual evaluation sheet with scoring rubric.
+- [ ] Automation script to replay evaluations after each change.

--- a/content/read/Athousandbrainstheorie.md
+++ b/content/read/Athousandbrainstheorie.md
@@ -49,3 +49,6 @@ This theory bridges the gap between neuroscience and artificial intelligence in 
 
 **Recommended for:** Anyone curious about how the brain works, interested in AI, or fascinated by the intersection of neuroscience and technology.
 
+### Personal Reflection
+
+Nach dem Lesen habe ich meine Erwartung an KI-Systeme anders bewertet: Viele kleine Modelle oder Agenten, die jeweils Teile der Welt abbilden, wirken realistischer als ein monolithischer Ansatz. Im Alltag bedeutet das für mich, Automationen modular zu bauen und ihnen jeweils klare, kleine Aufgaben zu geben.

--- a/content/read/Thinkingfastandslow.md
+++ b/content/read/Thinkingfastandslow.md
@@ -29,3 +29,15 @@ The book combines insights from psychology and behavioral economics, offering re
 ### Why This Matters
 
 Understanding these two systems of thought has profound implications for how we approach decisions, both personal and professional. By recognizing when System 1 (fast, emotional, automatic) versus System 2 (slow, deliberate, logical) thinking dominates, we can make more conscious choices about when to trust our instincts and when to slow down and think carefully.
+
+### Key Takeaways I Keep Using
+
+- **Priming-Effekte** sind real: Rahmenbedingungen beeinflussen Antworten stärker als gedacht.
+- **Verlustaversion** dominiert Entscheidungen; ich frage mich bewusst, ob ich gerade nur Angst vor Verlust habe.
+- **Ankereffekte** meiden: Zahlen zuerst aufschreiben, bevor ich mich von externen Werten leiten lasse.
+
+### Für wen das Buch passt
+
+- Menschen, die verstehen wollen, warum sie oft „aus dem Bauch“ handeln.
+- Führungskräfte, die Entscheidungsprozesse transparenter gestalten wollen.
+- Alle, die Biases in Meetings, Planung oder Risikoeinschätzungen reduzieren möchten.

--- a/content/read/_index.md
+++ b/content/read/_index.md
@@ -33,4 +33,9 @@ This section features books and audiobooks that have left an impression on me. E
 
 Someone invested significant time and effort into writing these works, which I believe enhances their quality. I only feature recommendations where I think this is particularly evident.
 
+### Wie ich lese und schreibe
+- Notiere pro Kapitel zwei Kernideen.
+- Markiere Stellen, die konkrete Handlungen auslösen (z. B. ein Experiment oder ein Gespräch).
+- Schreibe die Rezensionen kurz nach dem Lesen, ergänze später um gelebte Erfahrungen.
+
 ---


### PR DESCRIPTION
## Summary
- Enhanced every content section (home, blog, AI Blubber, IT Pro, projects, organisation, and reading) with richer explanations, checklists, and clearer expectations.
- Added operational tips for technical posts (Intune, AVD), refined creative workflows, and improved templates plus reflections across German and English entries.
- Updated project hubs and book notes with actionable guidance, personal takeaways, and publishing checklists for consistent presentation.

## Testing
- `zola build` *(fails locally: zola not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953feabc81c832ca8f675dfc8c97d49)