### PR TITLE
Refresh homepage hero and feature highlights

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,6 +4,26 @@ template = 'home.html'
 [extra]
 lang = 'en'
 
+# Hero presentation
+overline = "Automation strategist • Cloud reliability engineer"
+highlights = [
+    "Automation-first delivery and guardrails",
+    "Azure, AVD, and endpoint management",
+    "AI-assisted scripting and observability"
+]
+status_cards = [
+    { label = "Current focus", value = "Azure automation and digital workspace reliability" },
+    { label = "Building", value = "Opinionated runbooks, self-service tooling, and resilient workflows" },
+    { label = "Toolbox", value = "PowerShell, Bicep, DevOps pipelines, and a lot of curiosity" }
+]
+featured_sections = [
+    { name = "Projects", path = "/projects", description = "Automation builds, home lab experiments, and prototypes." },
+    { name = "IT Pro", path = "/it-pro", description = "Practical notes on Azure, virtualization, and endpoint management." },
+    { name = "AI Blubber", path = "/ai-blubber", description = "Hands-on AI workflows, promptcraft, and operational lessons." },
+    { name = "Read", path = "/read", description = "Reading notes and takeaways from technology and leadership books." }
+]
+contact_note = "Let’s design stable, automated workflows together."
+
 # Show footer in home page
 footer = false
 

--- a/static/custom.css
+++ b/static/custom.css
@@ -1,23 +1,12 @@
 /* Site Logo */
-#logo {
-  text-align: left;
-  margin-bottom: 2rem;
-  padding: 2rem 0;
-}
-
-.site-header {
-  display: flex;
-  justify-content: center;
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.site-header-inner {
-  width: 100%;
-  max-width: 1080px;
-  padding: 0.75rem 1.5rem;
+.logo-band {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding: 1.5rem 0 0.5rem;
+  border-bottom: 1px solid var(--border-accent);
 }
 
 .site-logo {
@@ -30,71 +19,224 @@
   display: block;
   height: 80px;
   width: auto;
-  margin-bottom: 1rem;
+  margin-bottom: 0.25rem;
   filter: drop-shadow(0 4px 8px var(--shadow-accent));
-  transition: transform 0.3s ease;
+  transition: transform 0.3s ease, filter 0.3s ease;
 }
 
 .site-logo-img:hover {
   transform: scale(1.05);
+  filter: drop-shadow(0 6px 14px var(--shadow-accent));
 }
 
-body.dark .site-header {
-  border-bottom-color: #222;
+.logo-overline {
+  font-size: 0.95rem;
+  color: var(--text-pale-color);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid var(--border-accent);
 }
 
-body.dark .site-logo-img {
-  filter: drop-shadow(0 0 4px rgba(0, 0, 0, 0.5));
-}
-
-/* Enhanced welcome message */
-#info {
-  position: relative;
-  padding: 2rem;
-  border-radius: 16px;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.8), rgba(248, 250, 252, 0.8));
+.hero-panel {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(248, 250, 252, 0.9));
   backdrop-filter: blur(10px);
   border: 1px solid var(--border-accent);
-  box-shadow: 0 8px 32px var(--shadow-accent);
+  box-shadow: 0 12px 36px var(--shadow-accent);
   margin-bottom: 2rem;
 }
 
-body.dark #info {
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.8), rgba(30, 41, 59, 0.8));
+body.dark .hero-panel {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.9));
+}
+
+.hero-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.hero-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  color: var(--text-pale-color);
+}
+
+.name-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
 }
 
 #name {
-  font-size: 1.8rem;
-  font-weight: 600;
+  font-size: 2rem;
+  font-weight: 700;
   color: var(--primary-accent);
+}
+
+#id {
+  font-size: 1rem;
+  color: var(--text-pale-color);
 }
 
 #bio {
   font-size: 1.1rem;
   line-height: 1.6;
   color: var(--text-color);
+  margin-top: 0.35rem;
+}
+
+.highlight-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.5rem 1rem;
+}
+
+.highlight-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(37, 99, 235, 0.05);
+  padding: 0.65rem 0.9rem;
+  border-radius: 10px;
+  border: 1px dashed var(--border-accent);
+}
+
+.checkmark {
+  color: var(--primary-accent);
+  font-weight: 700;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.status-card {
+  padding: 0.95rem 1rem;
+  border-radius: 12px;
+  background: linear-gradient(145deg, rgba(37, 99, 235, 0.08), rgba(6, 182, 212, 0.08));
+  border: 1px solid var(--border-accent);
+  box-shadow: 0 10px 24px var(--shadow-accent);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.status-card .label {
+  font-size: 0.9rem;
+  color: var(--text-pale-color);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.status-card .value {
+  font-size: 1.05rem;
+  color: var(--text-color);
+  font-weight: 600;
+}
+
+.link-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
   margin-top: 0.5rem;
 }
 
-/* Welcome animation */
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+.primary-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
-#logo, #info, #links {
-  animation: fadeInUp 0.8s ease-out;
+.primary-links a {
+  padding: 0.65rem 1.1rem;
+  border-radius: 10px;
+  border: 1px solid var(--border-accent);
+  background: var(--bg-color);
+  box-shadow: 0 6px 16px var(--shadow-accent);
+  font-weight: 600;
+  transition: all 0.25s ease;
 }
 
-#info {
-  animation-delay: 0.2s;
-  animation-fill-mode: both;
+.primary-links a:hover {
+  transform: translateY(-2px);
+  background: linear-gradient(135deg, var(--primary-accent), var(--secondary-accent));
+  color: white;
+}
+
+.social-links {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.social-links a,
+.social-links button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid var(--border-accent);
+  transition: all 0.25s ease;
+  padding: 0.35rem;
+  box-shadow: 0 6px 16px var(--shadow-accent);
+}
+
+.social-links a:hover,
+.social-links button:hover {
+  transform: translateY(-2px) scale(1.02);
+  background: linear-gradient(135deg, var(--primary-accent), var(--secondary-accent));
+  color: white;
+}
+
+.hero-aside {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.contact-card {
+  width: 100%;
+  padding: 1.25rem;
+  border-radius: 14px;
+  background: linear-gradient(145deg, rgba(37, 99, 235, 0.12), rgba(139, 92, 246, 0.12));
+  border: 1px solid var(--border-accent);
+  box-shadow: 0 12px 28px var(--shadow-accent);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.contact-card p {
+  margin: 0;
+  color: var(--text-color);
+}
+
+.contact-card .button {
+  align-self: flex-start;
 }
 
 #brief {
@@ -138,37 +280,72 @@ body.dark #brief {
   font-weight: 600;
 }
 
-/* Enhanced links section */
-#links {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.6), rgba(248, 250, 252, 0.6));
-  backdrop-filter: blur(10px);
-  border-radius: 12px;
-  padding: 1.5rem;
+.featured-grid {
+  background: rgba(255, 255, 255, 0.85);
   border: 1px solid var(--border-accent);
-  box-shadow: 0 4px 16px var(--shadow-accent);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px var(--shadow-accent);
   margin-bottom: 2rem;
 }
 
-body.dark #links {
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.6), rgba(30, 41, 59, 0.6));
+body.dark .featured-grid {
+  background: rgba(15, 23, 42, 0.9);
 }
 
-#left a {
-  display: inline-block;
-  padding: 0.75rem 1.5rem;
-  margin: 0.25rem;
-  border-radius: 8px;
-  background: var(--bg-color);
+.feature-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.feature-card {
+  border-radius: 14px;
   border: 1px solid var(--border-accent);
-  transition: all 0.3s ease;
-  font-weight: 500;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.6);
+  box-shadow: 0 8px 22px var(--shadow-accent);
+  transition: all 0.25s ease;
 }
 
-#left a:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px var(--shadow-accent);
-  background: var(--primary-accent);
-  color: white;
+body.dark .feature-card {
+  background: rgba(30, 41, 59, 0.7);
+}
+
+.feature-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-accent);
+  box-shadow: 0 14px 32px var(--shadow-accent);
+}
+
+.feature-card p {
+  margin: 0.5rem 0 0;
+  color: var(--text-color);
+  line-height: 1.5;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary-accent);
+  font-weight: 700;
+  border: 1px solid var(--border-accent);
+}
+
+.arrow {
+  font-size: 1.25rem;
+  color: var(--primary-accent);
 }
 
 /* Hero section background */
@@ -256,6 +433,16 @@ button, .button, a.instant, #back-link {
 button:hover, .button:hover, a.instant:hover, #back-link:hover {
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(37, 99, 235, 0.3);
+}
+
+.primary-links a.instant {
+  background: var(--bg-color);
+  color: inherit;
+  border: 1px solid var(--border-accent);
+}
+
+.primary-links a.instant:hover {
+  color: white;
 }
 
 /* Post cards enhancement */
@@ -512,5 +699,31 @@ body.dark .post-meta .reading-time {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
+  }
+}
+
+@media (max-width: 960px) {
+  .hero-panel {
+    grid-template-columns: 1fr;
+    padding: 1.25rem;
+  }
+
+  .logo-band {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .link-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .social-links {
+    width: 100%;
+  }
+
+  .hero-aside .contact-card {
+    align-self: stretch;
   }
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -35,8 +35,7 @@
 {% block content %}
 <div id="wrapper">
   <main>
-    <!-- Site Logo -->
-    <section id="logo">
+    <section id="logo" class="logo-band">
       <a href="{{ get_url(path='/') }}" class="site-logo" aria-label="MelfWare - Home">
         <img
           src="{{ get_url(path='img/melfware-logo.svg') }}"
@@ -44,46 +43,88 @@
           class="site-logo-img"
         >
       </a>
+      {% if section.extra.overline %}
+      <div class="logo-overline">{{ section.extra.overline }}</div>
+      {% endif %}
     </section>
 
-    <section id="info">
-      {% if section.extra.avatar %}
-      <img src="{{ get_url(path=section.extra.avatar) }}" alt="avatar">
-      {% endif %}
-      <div id="text">
-        <div>
-          <span id="name">{{ section.extra.name }}</span>
-          {% if section.extra.id %}
-          <span id="id">@{{ section.extra.id }}</span>
+    <section id="info" class="hero-panel">
+      <div class="hero-main">
+        <div class="hero-header">
+          <div>
+            <span class="eyebrow">Stefan “Melf” Moser</span>
+            <div class="name-row">
+              <span id="name">{{ section.extra.name }}</span>
+              {% if section.extra.id %}
+              <span id="id">@{{ section.extra.id }}</span>
+              {% endif %}
+            </div>
+            {% if section.extra.bio %}
+            <p id="bio">{{ section.extra.bio }}</p>
+            {% endif %}
+          </div>
+        </div>
+
+        {% if section.extra.highlights %}
+        <ul class="highlight-list">
+          {% for item in section.extra.highlights %}
+          <li>
+            <span class="checkmark">•</span>
+            <span>{{ item }}</span>
+          </li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+        {% if section.extra.status_cards %}
+        <div class="status-grid">
+          {% for stat in section.extra.status_cards %}
+          <div class="status-card">
+            <span class="label">{{ stat.label }}</span>
+            <span class="value">{{ stat.value }}</span>
+          </div>
+          {% endfor %}
+        </div>
+        {% endif %}
+
+        <div class="link-row">
+          <div class="primary-links">
+            {% for section in config.extra.sections %}
+            <a {% if section.is_external %}href="{{ section.path }}" target="_blank" rel='noreferrer noopener'{% else %}href="{{ get_url(path=section.path) }}" class="instant"{% endif %}>{{ section.name }}</a>
+            {% endfor %}
+          </div>
+          <div class="social-links">
+            {% for link in section.extra.links %}
+            <a href="{{ link.url }}" aria-label="{{ link.name }}" target="_blank" rel='noreferrer noopener'>
+              {% set icon_path = "icon/" ~ link.icon ~ ".svg" %}
+              {% set icon = load_data(path=icon_path) %}
+              {{ icon | safe }}
+            </a>
+            {% endfor %}
+            {% if not section.extra.footer and not config.extra.force_theme %}
+            {% set moon_icon = load_data(path="icon/moon.svg") %}
+            {% set sun_icon = load_data(path="icon/sun.svg") %}
+            <button id="theme-toggle" aria-label="theme switch">
+              <span class="moon-icon">{{ moon_icon | safe }}</span>
+              <span class="sun-icon">{{ sun_icon | safe }}</span>
+            </button>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+
+      <div class="hero-aside">
+        {% if section.extra.contact_note %}
+        <div class="contact-card">
+          <p>{{ section.extra.contact_note }}</p>
+          {% if section.extra.links %}
+            {% for link in section.extra.links %}
+              {% if link.name == "Email" %}
+              <a class="button instant" href="{{ link.url }}">Start a conversation</a>
+              {% endif %}
+            {% endfor %}
           {% endif %}
         </div>
-        {% if section.extra.bio %}
-        <div id="bio"> {{ section.extra.bio }} </div>
-        {% endif %}
-      </div>
-    </section>
-
-    <section id="links">
-      <div id="left">
-        {% for section in config.extra.sections %}
-        <a {% if section.is_external %}href="{{ section.path }}" target="_blank" rel='noreferrer noopener'{% else %}href="{{ get_url(path=section.path) }}" class="instant"{% endif %}>{{ section.name }}</a>
-        {% endfor %}
-      </div>
-      <div id="right">
-        {% for link in section.extra.links %}
-        <a href="{{ link.url }}" aria-label="{{ link.name }}" target="_blank" rel='noreferrer noopener'>
-          {% set icon_path = "icon/" ~ link.icon ~ ".svg" %}
-          {% set icon = load_data(path=icon_path) %}
-          {{ icon | safe }}
-        </a>
-        {% endfor %}
-        {% if not section.extra.footer and not config.extra.force_theme %}
-        {% set moon_icon = load_data(path="icon/moon.svg") %}
-        {% set sun_icon = load_data(path="icon/sun.svg") %}
-        <button id="theme-toggle" aria-label="theme switch">
-          <span class="moon-icon">{{ moon_icon | safe }}</span>
-          <span class="sun-icon">{{ sun_icon | safe }}</span>
-        </button>
         {% endif %}
       </div>
     </section>
@@ -91,6 +132,26 @@
     <section id="brief" class="prose">
       {{ section.content | trim | safe }}
     </section>
+
+    {% if section.extra.featured_sections %}
+    <section class="featured-grid">
+      <div class="section-title">
+        <p class="eyebrow">Explore</p>
+        <h2>Start with a focus area</h2>
+      </div>
+      <div class="feature-cards">
+        {% for item in section.extra.featured_sections %}
+        <a class="feature-card instant" href="{{ get_url(path=item.path) }}">
+          <div class="card-header">
+            <span class="pill">{{ item.name }}</span>
+            <span class="arrow">→</span>
+          </div>
+          <p>{{ item.description }}</p>
+        </a>
+        {% endfor %}
+      </div>
+    </section>
+    {% endif %}
 
     {% if section.extra.recent %}
     {% set blog_section_path = config.extra.blog_section_path | trim_start_matches(pat="/") %}


### PR DESCRIPTION
## Summary
- Refresh the homepage hero with an overline, highlights, and automation status cards for clearer positioning
- Add a featured focus-area grid plus a contact call-to-action fed by new front matter fields
- Update custom styling for the hero, navigation buttons, and responsive behavior

## Testing
- `zola build` *(fails: command not available in container)*

## Screenshots
- Not captured (Zola is not available in the container to run the site)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695403e7d3e4832c9bf9d83f24d1fa48)