### PR TITLE
fix: deploy on default branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build and deploy GH Pages
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
### Motivation
- Fix deployment workflow which was only triggering for the hardcoded `main` branch so deployments failed when the repository default branch differs.

### Description
- Update `.github/workflows/build.yml` to change the job condition from `github.ref == 'refs/heads/main'` to `github.ref == format('refs/heads/{0}', github.event.repository.default_branch)` so the workflow runs on the repository’s default branch.

### Testing
- Ran `zola build` in the environment but it failed because `zola` is not installed (command not found), so no local automated build could be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968034635b8832cbc4525a755a13745)