### PR TITLE
fix: update Zola version for GitHub Pages workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Zola
         uses: taiki-e/install-action@v2
         with:
-          tool: zola@0.20.0
+          tool: zola@0.22.0
 
       - name: Build site
         run: |


### PR DESCRIPTION
### Motivation
- Align the CI workflow with the site configuration by installing `zola@0.22.0` so builds on GitHub Actions use the same Zola version and avoid build/deploy errors.

### Description
- Update ` .github/workflows/build.yml` to change the `taiki-e/install-action@v2` `tool` from `zola@0.20.0` to `zola@0.22.0`.

### Testing
- No automated tests were run for this workflow-only change; verification can be done by running `zola build` locally or letting the GitHub Actions workflow run on the next push.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696804a45c80832cab705480408d1b57)