### PR TITLE
fix: align local Zola install version with CI (0.22.0)

### DIFF
--- a/scripts/install-zola.sh
+++ b/scripts/install-zola.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Installs a pinned Zola binary into ./bin for local builds/tests.
-ZOLA_VERSION="${ZOLA_VERSION:-0.19.2}"
+ZOLA_VERSION="${ZOLA_VERSION:-0.22.0}"
 INSTALL_DIR="${ZOLA_BIN_DIR:-./bin}"
 
 OS="$(uname -s)"


### PR DESCRIPTION
### Motivation
- Ensure the local install script installs the same Zola version used in CI (`0.22.0`) to avoid inconsistencies with `config.toml` and CI builds.

### Description
- Update the default `ZOLA_VERSION` in `scripts/install-zola.sh` from `0.19.2` to `0.22.0`.

### Testing
- No automated tests exist for this project; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696808dd01e8832cab688c4282b32923)