### PR TITLE
fix: load serene highlight themes correctly

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,14 +20,14 @@ external_links_no_referrer = true
 smart_punctuation = false
 
 # Zola 0.22 expects `markdown.highlighting` to be a struct (not a boolean).
-# We vendor Serene's TextMate themes into `highlight_themes/` so builds can
+# We vendor Serene's TextMate themes into `highlight_themes/themes/` so builds can
 # resolve them without depending on theme submodule paths.
 
 [markdown.highlighting]
 enable = true
 # Theme keys are the file stems (no `.tmTheme`).
 theme = "serene-dark"
-extra_syntaxes_and_themes = ["highlight_themes"]
+extra_syntaxes_and_themes = ["highlight_themes/themes"]
 themes_css = [
   { theme = "serene-light", filename = "hl-light.css" },
   { theme = "serene-dark", filename = "hl-dark.css" },


### PR DESCRIPTION
### Motivation
- `zola build` failed because the vendored Serene TextMate themes were referenced at the wrong path, so the configured `markdown.highlighting` themes could not be found.

### Description
- Update `config.toml` to point `extra_syntaxes_and_themes` at `"highlight_themes/themes"` and adjust the explanatory comment to match the actual directory layout.

### Testing
- This project has no automated tests and no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696809acb37c832cb5022f4848968ccd)