### PR TITLE
fix: resolve highlight theme path

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,7 +27,7 @@ smart_punctuation = false
 enable = true
 # Theme keys are the file stems (no `.tmTheme`).
 theme = "serene-dark"
-extra_syntaxes_and_themes = ["highlight_themes/themes"]
+extra_syntaxes_and_themes = ["highlight_themes"]
 themes_css = [
   { theme = "serene-light", filename = "hl-light.css" },
   { theme = "serene-dark", filename = "hl-dark.css" },


### PR DESCRIPTION
### Motivation
- Fix Zola build error where `serene-dark` couldn't be resolved due to an incorrect `extra_syntaxes_and_themes` path.

### Description
- Update `config.toml` to set `extra_syntaxes_and_themes = ["highlight_themes"]`, replacing `["highlight_themes/themes"]` so Zola can locate the vendored TextMate themes.

### Testing
- No automated tests were run; `zola build` was not executed because the `zola` binary is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69680ab53aa0832c9812eb0c31dad1d2)